### PR TITLE
Enable ChatScreen preview by bypassing API key check

### DIFF
--- a/app/src/main/java/com/skushagra/selfselect/ChatScreen.kt
+++ b/app/src/main/java/com/skushagra/selfselect/ChatScreen.kt
@@ -175,5 +175,8 @@ fun ChatScreen(
 @Preview(showSystemUi = true)
 @Composable
 fun ChatScreenPreview() {
-    ChatScreen()
+    val context = LocalContext.current
+    val application = context.applicationContext as android.app.Application
+    val previewViewModel = ChatViewModel(application = application, isPreview = true)
+    ChatScreen(chatViewModel = previewViewModel)
 }

--- a/app/src/main/java/com/skushagra/selfselect/ChatViewModel.kt
+++ b/app/src/main/java/com/skushagra/selfselect/ChatViewModel.kt
@@ -27,13 +27,16 @@ data class ChatMessage(
     val sender: Sender
 )
 
-class ChatViewModel(application: Application) : AndroidViewModel(application) {
+class ChatViewModel(application: Application, isPreview: Boolean) : AndroidViewModel(application) {
 
     private var generativeModel: GenerativeModel? = null
     private var conversation: Chat? = null
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Initial)
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    // Secondary constructor for existing code, defaults to not being a preview
+    constructor(application: Application) : this(application, false)
 
     companion object {
         private const val PREFS_NAME = "selfselect_prefs" // Used by EncryptedSharedPreferences
@@ -42,7 +45,11 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     init {
-        checkForApiKey(application.applicationContext)
+        if (isPreview) {
+            _uiState.value = UiState.Success("Preview mode: Chat functionality is disabled.")
+        } else {
+            checkForApiKey(application.applicationContext)
+        }
     }
 
     private fun storeApiKey(context: Context, apiKey: String) {


### PR DESCRIPTION
The ChatScreen @Preview was failing to render because its ChatViewModel instance would trigger an API key check and attempt to show an ApiKeyEntryDialog. Previews do not handle this workflow well.

This commit introduces a mechanism to allow the ChatViewModel to be instantiated in a 'preview mode':
- Added a secondary constructor to ChatViewModel that accepts an `isPreview` boolean flag.
- If `isPreview` is true, the ViewModel bypasses the API key check and initializes with a default success state (`UiState.Success`).
- The `ChatScreenPreview` composable in `ChatScreen.kt` now uses this new constructor to provide a preview-safe ChatViewModel instance to the ChatScreen.

This allows the ChatScreen to render in preview mode without altering the runtime API key logic.